### PR TITLE
docs: 📝 migrate GitHub stats to self-hosted Vercel service

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ I am a Software Engineer II with strong expertise in backend development, API de
 
 <b>My GitHub Stats</b>
 
-<a href="http://www.github.com/mmoore96"><img src="https://github-readme-stats.vercel.app/api?username=mmoore96&show_icons=true&hide=&count_private=true&title_color=0891b2&text_color=ffffff&icon_color=0891b2&bg_color=1c1917&hide_border=true&show_icons=true" alt="mmoore96's GitHub stats" /></a>
+<a href="http://www.github.com/mmoore96"><img src="https://github-readme-stats-inky-psi-71.vercel.app/api?username=mmoore96&show_icons=true&hide=&count_private=true&title_color=0891b2&text_color=ffffff&icon_color=0891b2&bg_color=1c1917&hide_border=true&show_icons=true" alt="mmoore96's GitHub stats" /></a>
 
 <a href="http://www.github.com/mmoore96"><img src="https://github-readme-streak-stats.herokuapp.com/?user=mmoore96&stroke=ffffff&background=1c1917&ring=0891b2&fire=0891b2&currStreakNum=ffffff&currStreakLabel=0891b2&sideNums=ffffff&sideLabels=ffffff&dates=ffffff&hide_border=true" /></a>


### PR DESCRIPTION
## Pull Request: 📝 Update GitHub Stats Source in README

👤 **Documentation Update Overview**  
_This Pull Request involves an update to the GitHub README file, specifically the section displaying GitHub statistics. The source of these statistics has been changed from the default hosted service to a self-hosted version on Vercel. This change allows the inclusion of private repository stats in the displayed GitHub profile statistics._

🔍 **Details of Update**  
The modification to the GitHub stats source in the README is a focused update aimed at enhancing the personalization and comprehensiveness of the profile statistics:
- **Change in Stats Source**: The source URL for the GitHub Readme Stats has been switched to a self-hosted version on Vercel (`https://github-readme-stats-inky-psi-71.vercel.app/api?username=mmoore96&...`). This self-hosted approach allows for the inclusion of private repository statistics, which were previously not displayed.

🚀 **Impact of Changes**  
The update to use a self-hosted stats service for GitHub README has multiple benefits:
- **Enhanced Profile Representation**: Including private repository stats offers a more complete overview of the user's GitHub activities.
- **Increased Data Control**: Self-hosting the stats service provides more control over the data presentation and privacy.

🧪 **Testing and Validation**  
To ensure that the transition to a self-hosted stats service is seamless and functional, the following steps were undertaken:
- **Visual Verification**: Ensured that the GitHub README accurately renders the statistics from the new self-hosted source.
- **Link Functionality Test**: Checked all hyperlinks to ensure they correctly point to the new stats service and are functional.

## 🌳 Branch  
`docs/self-host-github-stats`